### PR TITLE
Allow local (or temporary) settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 db.sqlite3
+local_settings.py

--- a/pybd/settings.py
+++ b/pybd/settings.py
@@ -118,3 +118,11 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
+
+IMPORT_LOCAL_SETTINGS = False
+
+if IMPORT_LOCAL_SETTINGS:
+    try:
+        from .local_settings import *
+    except ImportError:
+        pass


### PR DESCRIPTION
Often some local and/or temporary settings are required during development and testing, which are not intended to be committed. Lets have a separate file, local_settings.py, and use it for local and/or temporary settings.